### PR TITLE
Show that bug #58102 is not really a bug, but behaves as expected

### DIFF
--- a/ext/spl/tests/bug58102.phpt
+++ b/ext/spl/tests/bug58102.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #581092 (Cannot pass COUNT_RECURSIVE to Countable)
+Bug #58102 (Cannot pass COUNT_RECURSIVE to Countable)
 --CREDITS--
 KCPHPUG TestFest 2017 - Eric Poe
 --FILE--

--- a/ext/spl/tests/bug581092.phpt
+++ b/ext/spl/tests/bug581092.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Bug #581092 (Cannot pass COUNT_RECURSIVE to Countable)
+--CREDITS--
+KCPHPUG TestFest 2017 - Eric Poe
+--FILE--
+<?php
+class MyCountableIterator implements RecursiveIterator, Countable
+{
+    protected $toIterate;
+    protected $pointer;
+
+    public function __construct(array $thingToIterate = [])
+    {
+        $this->toIterate = $thingToIterate;
+        $this->pointer = 0;
+    }
+
+    public function current()
+    {
+        return $this->toIterate[$this->pointer];
+    }
+
+    public function next()
+    {
+        $this->pointer++;
+    }
+
+    public function key()
+    {
+        return $this->pointer;
+    }
+
+    public function valid()
+    {
+        return $this->pointer < $this->count();
+    }
+
+    public function rewind()
+    {
+        $this->pointer = 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasChildren()
+    {
+        return (count($this->getChildren()) > 0);
+    }
+
+    /**
+     * @return MyCountableIterator
+     */
+    public function getChildren()
+    {
+        return new MyCountableIterator($this->toIterate[$this->key()]);
+    }
+
+    public function count()
+    {
+        // count first level of the multidimensional array
+        return count($this->toIterate);
+    }
+}
+
+$multiObject = [];
+$multiObject[] = range(1, 5);
+$multiObject[] = range(6, 10);
+$multiObject[] = range(11, 15);
+
+printf(
+    "%s\n%s",
+    count(new MyCountableIterator($multiObject), COUNT_RECURSIVE),
+    count(iterator_to_array(new MyCountableIterator($multiObject)), COUNT_RECURSIVE)
+);
+--EXPECT--
+3
+18


### PR DESCRIPTION
Bug [#58102](https://bugs.php.net/bug.php?id=58102) reports that `count(ReverseIterator-that-Implements-Countable, COUNT_RECURSIVE)` returns whatever the count method of that class returns. That is by design since that is the definition of how the `count` function works on `Countable::count()`.  See: http://php.net/manual/en/function.count.php#refsect1-function.count-description

This test submitted as part of KCPHPUG TestFest 2017.