### PR TITLE
added basic test for ZipArchive::unchangeName()

### DIFF
--- a/ext/zip/tests/oo_unchangeName.phpt
+++ b/ext/zip/tests/oo_unchangeName.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test basic ZipArchive::unchangeName() method
+--CREDIT--
+PHP TestFest 2017 - Bergfreunde, Florian Engelhardt
+--SKIPIF--
+<?php if (!extension_loaded("zip")) print "skip"; ?>
+--FILE--
+<?php
+$dirname = dirname(__FILE__) . '/';
+$file = $dirname . '__tmp_oo_unchangeIndex.zip';
+copy($dirname.'test.zip', $file);
+
+var_dump(md5_file($file));
+
+$zip = new ZipArchive();
+$zip->open($file);
+var_dump($zip->getNameIndex(0));
+var_dump($zip->getCommentIndex(0));
+
+$zip->renameIndex(0, 'baz filename');
+$zip->setCommentIndex(0, 'baz comment');
+
+var_dump($zip->getNameIndex(0));
+var_dump($zip->getCommentIndex(0));
+
+$zip->unchangeName('baz filename');
+
+var_dump($zip->getNameIndex(0));
+var_dump($zip->getCommentIndex(0));
+
+var_dump(md5_file($file));
+
+unlink($file);
+?>
+--EXPECT--
+string(32) "cb753d0a812b2edb386bdcbc4cd7d131"
+string(3) "bar"
+string(0) ""
+string(12) "baz filename"
+string(11) "baz comment"
+string(3) "bar"
+string(0) ""
+string(32) "cb753d0a812b2edb386bdcbc4cd7d131"


### PR DESCRIPTION
User Group: Bergfreunde
Just a basic test for ZipArchive::unchangeName()

This is in principle the same content as in #11, but calling `unchangeName()` instead of `unchangeIndex()`.  Should i merge those to tests into one file, or is it better to have that split, even if the test are nearly identical?