### PR TITLE
Show that bug #60161 still exists

### DIFF
--- a/ext/spl/tests/bug60161.phpt
+++ b/ext/spl/tests/bug60161.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Bug #60161 (Implementing an interface extending Traversable is order dependent)
+--CREDIT--
+KCPHPUG TestFest 2017 - Eric Poe
+--FILE--
+<?php
+interface Foo extends \Traversable {}
+interface Bar {}
+
+Class A implements \IteratorAggregate, Foo, Bar
+{
+  public function getIterator()
+  {
+    return new \ArrayIterator([]);
+  }
+}
+
+class B implements Foo, \IteratorAggregate, Bar
+{
+  public function getIterator()
+  {
+    return new \ArrayIterator([]);
+  }
+}
+
+class C implements Foo, Bar, \IteratorAggregate
+{
+  public function getIterator()
+  {
+    return new \ArrayIterator([]);
+  }
+}
+
+echo "OK";
+?>
+--XFAIL--
+This will fail until the interface-order Bug #60161 is no longer a problem
+--EXPECT--
+OK


### PR DESCRIPTION
This PR shows that [bug #60161](https://bugs.php.net/bug.php?id=60161) still exists. Unfortunately, the original code examples no longer exist, but the 3v4l.org examples from a few years ago still exist. This PR adds those code examples as tests.

User Group: Kansas City PHP