### PR TITLE
ext/mbstring: Add test for mb_language() error case

### DIFF
--- a/ext/mbstring/tests/mb_language_error.phpt
+++ b/ext/mbstring/tests/mb_language_error.phpt
@@ -1,0 +1,14 @@
+--TEST--
+mb_language() - invalid language error case
+--CREDITS--
+Chicago PHP UG
+# TestFest 2017-09-18
+--SKIPIF--
+<?php if (!extension_loaded('mbstring')) die('skip ext/mbstring required'); ?>
+--FILE--
+<?php
+var_dump(mb_language('Foo'));
+?>
+--EXPECTF--
+Warning: mb_language(): Unknown language "Foo" in %s on line %d
+bool(false)


### PR DESCRIPTION
Adding a test that covers the error case for `mb_language()`. This was created by the Chicago PHP UG! Yay! :) :D