### PR TITLE
Add test for date_time_immutable invalid arguments

### DIFF
--- a/ext/date/tests/date_time_immutable001.phpt
+++ b/ext/date/tests/date_time_immutable001.phpt
@@ -1,0 +1,10 @@
+--TEST--
+DateTimeImmutable - invalid arguments
+--CREDITS--
+Mark Niebergall mbniebergall@gmail.com UPHPU TestFest 2017
+--FILE--
+<?php
+var_dump(date_create_immutable('Invalid'));
+?>
+--EXPECTF--
+bool(false)


### PR DESCRIPTION
Added a test for invalid arguments to date_time_immutable for missing tests for http://gcov.php.net/PHP_7_1/lcov_html/ext/date/php_date.c.gcov.php around line 2723 for RETURN FALSE

UPHPU TestFest 2017