### PR TITLE
adds test for bug 70110

### DIFF
--- a/ext/pcre/tests/bug70110.phpt
+++ b/ext/pcre/tests/bug70110.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Check for breaking regex - see bug 70110
+--XFAIL--
+Fails during execution of regex
+--FILE--
+<?php
+
+var_dump(preg_match('/^(A{1,2}B)+$/',str_repeat('AB',8192)));
+
+?>
+--EXPECT--
+int(1)
+


### PR DESCRIPTION
This tests that certain regexes actually fail at the moment. For more information have a look at https://bugs.php.net/bug.php?id=70110

This is the second PR of the PHPUGFFM for the PHPTestFest 2017