### PR TITLE
Add test for error_clear_last with invalid arguments

### DIFF
--- a/ext/standard/tests/general_functions/error_clear_last_error.phpt
+++ b/ext/standard/tests/general_functions/error_clear_last_error.phpt
@@ -1,0 +1,12 @@
+--TEST--
+error_clear_last() - with args
+--CREDIT--
+Marcos Minond minond.marcos@gmail.com UPHPU TestFest 2017
+--FILE--
+<?php
+
+error_clear_last("with arguments");
+
+?>
+--EXPECTF--	
+Warning: error_clear_last() expects exactly 0 parameters, 1 given in %s on line %d


### PR DESCRIPTION
Adds coverage for when `error_clear_last` is called with an argument, which it does not expect, and is supposed to immediately return and log a warning.

Doing this as part of UPHPU's 2017 TestFest.