### PR TITLE
test warning for nul args on register_shutdown_functions

### DIFF
--- a/ext/standard/tests/reg_shutdown_func.phpt
+++ b/ext/standard/tests/reg_shutdown_func.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Check the register_shutdown_function parameters
+--FILE--
+<?php
+register_shutdown_function();
+?>
+--EXPECTF--
+Warning: Wrong parameter count for register_shutdown_function() in %s on line %d
+false

--- a/ext/standard/tests/reg_shutdown_func.phpt
+++ b/ext/standard/tests/reg_shutdown_func.phpt
@@ -1,9 +1,10 @@
 --TEST--
-Check the register_shutdown_function parameters
+register_shutdown_function - invalid arguments
+--CREDITS--
+Matthew Hill mahelious@gmail.com UPHPU TestFest 2017
 --FILE--
 <?php
 register_shutdown_function();
 ?>
 --EXPECTF--
 Warning: Wrong parameter count for register_shutdown_function() in %s on line %d
-false


### PR DESCRIPTION
test register_shutdown_function() throws a warning when called with no args

code coverage on http://gcov.php.net/PHP_7_0/lcov_html/ext/standard/basic_functions.c.gcov.php::5038

User Group : Utah PHP