### PR TITLE
Added a test for date_sub invalid arguments

### DIFF
--- a/ext/date/tests/date_sub_param_error.phpt
+++ b/ext/date/tests/date_sub_param_error.phpt
@@ -1,0 +1,11 @@
+--TEST--
+date_sub - invalid arguments
+--CREDITS--
+Derek Caswell derek.caswell@gmail.com UPHPU TestFest 2017
+--FILE--
+<?php
+var_dump(date_sub('asdf', 'asdf'));
+?>
+--EXPECTF--
+Warning: date_sub() expects parameter 1 to be DateTime, string given in %s on line %d
+bool(false)


### PR DESCRIPTION
Added a test for date_sub() with invalid arguments being passed. This adds coverage in http://gcov.php.net/PHP_7_0/lcov_html/ext/date/php_date.c.gcov.php for the line that says RETURN FALSE; around line number 3249.

UPHPU TestFest 2017