### PR TITLE
Added basic tests for http_response_code

### DIFF
--- a/ext/standard/tests/http/http_response_code_basic.phpt
+++ b/ext/standard/tests/http/http_response_code_basic.phpt
@@ -9,7 +9,6 @@ var_dump(http_response_code(200));
 var_dump(http_response_code(404));
 var_dump(http_response_code(404));
 var_dump(http_response_code());
-var_dump(http_response_code('Invalid'));
 ?>
 --EXPECTF--
 bool(false)
@@ -17,6 +16,3 @@ bool(true)
 int(200)
 int(404)
 int(404)
-
-Warning: http_response_code() expects parameter 1 to be integer, string given in %s on line %d
-NULL

--- a/ext/standard/tests/http/http_response_code_basic.phpt
+++ b/ext/standard/tests/http/http_response_code_basic.phpt
@@ -1,0 +1,22 @@
+--TEST--
+http_response_code - basic tests
+--CREDITS--
+Mark Niebergall mbniebergall@gmail.com UPHPU TestFest 2017
+--FILE--
+<?php
+var_dump(http_response_code());
+var_dump(http_response_code(200));
+var_dump(http_response_code(404));
+var_dump(http_response_code(404));
+var_dump(http_response_code());
+var_dump(http_response_code('Invalid'));
+?>
+--EXPECTF--
+bool(false)
+bool(true)
+int(200)
+int(404)
+int(404)
+
+Warning: http_response_code() expects parameter 1 to be integer, string given in %s on line %d
+NULL


### PR DESCRIPTION
Added basic tests for `http_response_code` since there weren't any yet.

Covers http://gcov.php.net/PHP_7_2/lcov_html/ext/standard/head.c.gcov.php lines 318-345

UPHPU (Utah PHP User Group) for PHP TestFest 2017