### PR TITLE
mb_encoding_alias_error test

### DIFF
--- a/ext/mbstring/tests/mb_encoding_alias_error.phpt
+++ b/ext/mbstring/tests/mb_encoding_alias_error.phpt
@@ -1,0 +1,13 @@
+--TEST--
+mb_encoding_aliases - error
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--FILE--
+<?php
+    $result = mb_encoding_aliases(null);
+
+    var_dump($result);
+?>
+--EXPECTF--
+Warning: mb_encoding_aliases(): Unknown encoding "" in %s on line %d
+bool(false)


### PR DESCRIPTION
Added error test(s) for mb_encoding_alias

http://gcov.php.net/PHP_7_2/lcov_html/ext/mbstring/mbstring.c.gcov.php 3610-3611

UPHPU (Utah PHP User Group) for PHP TestFest 2017
