### PR TITLE
test readline() with EOF returns false

### DIFF
--- a/ext/readline/tests/readline_eof.phpt
+++ b/ext/readline/tests/readline_eof.phpt
@@ -1,0 +1,11 @@
+--TEST--
+readline - test passing EOF returns false
+--SKIPIF--
+<?php if (!extension_loaded("readline")) die("skip"); ?>
+--FILE--
+<?php
+var_dump(readline("Test Ctrl+D:"));
+?>
+--STDIN--
+--EXPECT--
+Test Ctrl+D:bool(false)


### PR DESCRIPTION
User Group: Madison PHP
Tests that passing EOF (Ctrl+D) to readline returns false