### PR TITLE
Add test to ensure realpath_cache_size doesn't take parameters

### DIFF
--- a/ext/standard/tests/file/realpath_cache_error.phpt
+++ b/ext/standard/tests/file/realpath_cache_error.phpt
@@ -1,0 +1,20 @@
+--TEST--
+realpath_cache_size() do not accept parameters
+--CREDITS--
+David Stockton dave@davidstockton.com i3logix PHP Testfest 2017
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die('skip not on Windows');
+}
+?>
+--FILE--
+<?php
+var_dump(realpath_cache_size('foo'));
+
+echo "Done\n";
+?>
+--EXPECTF--	
+Warning: realpath_cache_size() expects exactly 0 parameters, 1 given in %s on line %d
+NULL
+Done


### PR DESCRIPTION
Covers line 1106 of http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/filestat.c.gcov.php

i3logix PHP Testfest 2017