### PR TITLE
tmpfile called with parameters causes warning

### DIFF
--- a/ext/standard/tests/file/tmpfile_expects_no_parameters.phpt
+++ b/ext/standard/tests/file/tmpfile_expects_no_parameters.phpt
@@ -1,0 +1,9 @@
+--TEST--
+tmpfile expecting no parameters error
+--FILE--
+<?php
+var_dump(tmpfile('blah'));
+?>
+--EXPECTF--
+Warning: tmpfile() expects exactly 0 parameters, 1 given in %s on line %d
+NULL


### PR DESCRIPTION
tmpfile called with parameters causes warning

i3logix PHP Testfest 2017

http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/file.c.gcov.php 854-856