### PR TITLE
fnmatch error when pattern or filename too long

### DIFF
--- a/ext/standard/tests/file/fnmatch_maxpathlen.phpt
+++ b/ext/standard/tests/file/fnmatch_maxpathlen.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test fnmatch() function : warning filename or pattern exceeds maxpathlen
+--FILE--
+<?php
+$longstring = str_pad('blah', PHP_MAXPATHLEN);
+var_dump(fnmatch('blah', $longstring));
+var_dump(fnmatch($longstring, 'blah'));
+?>
+--EXPECTF--
+Warning: fnmatch(): Filename exceeds the maximum allowed length of %d characters in %s on line %d
+bool(false)
+
+Warning: fnmatch(): Pattern exceeds the maximum allowed length of %d characters in %s on line %d
+bool(false)


### PR DESCRIPTION
fnmatch error when pattern or filename too long

i3logix PHP Testfest 2017

http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/file.c.gcov.php 2497-2504