### PR TITLE
Add test for null return on version_compare with bad operator

### DIFF
--- a/ext/standard/tests/versioning/version_compare_invalid_operator.phpt
+++ b/ext/standard/tests/versioning/version_compare_invalid_operator.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Ensures null is returned if versions are compared with invalid operator
+--CREDITS--
+David Stockton - <dave@davidstockton.com> - i3logix PHP Testfest 2017
+--SKIPIF--
+
+--FILE--
+<?php
+var_dump(version_compare('1.2', '2.1', '??'));
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
Test covers previously uncovered line at http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/versioning.c.gcov.php : 246

Ensures that the function returns null if the operator is not recognized