### PR TITLE
PHP TestFest 2017 at PHPNW17 Conference - New tests for Closures

### DIFF
--- a/Zend/tests/closures/closure_instantiate.phpt
+++ b/Zend/tests/closures/closure_instantiate.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Closures cannot be instantiated directly
+--CREDITS--
+Mark Baker mark@lange.demon.co.uk at the PHPNW2017 Conference for PHP Testfest 2017
 --FILE--
 <?php
 

--- a/Zend/tests/closures/closure_instantiate.phpt
+++ b/Zend/tests/closures/closure_instantiate.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Closures cannot be instantiated
+--FILE--
+<?php
+
+try {
+    $x = new Closure();
+} catch (Exception $e) {
+    echo 'EXCEPTION: ', $e->getMessage();
+} catch (Throwable $e) {
+    echo 'ERROR: ', $e->getMessage();
+}
+
+?>
+--EXPECTF--
+ERROR: Instantiation of 'Closure' is not allowed

--- a/Zend/tests/closures/closure_instantiate.phpt
+++ b/Zend/tests/closures/closure_instantiate.phpt
@@ -1,16 +1,19 @@
 --TEST--
-Closures cannot be instantiated
+Closures cannot be instantiated directly
 --FILE--
 <?php
 
 try {
+    // Closures should be instantiatable using new
     $x = new Closure();
 } catch (Exception $e) {
+    // Instantiating a closure is an error, not an exception, so we shouldn't see this
     echo 'EXCEPTION: ', $e->getMessage();
 } catch (Throwable $e) {
+    // This is the mesage that we should see for a caught error
     echo 'ERROR: ', $e->getMessage();
 }
 
 ?>
---EXPECTF--
+--EXPECT--
 ERROR: Instantiation of 'Closure' is not allowed


### PR DESCRIPTION
Test to verify that closures can't be instantiated