### PR TITLE
added basic test for UConverter::getSourceEncoding()

### DIFF
--- a/ext/intl/tests/uconverter_getSourceEncoding.phpt
+++ b/ext/intl/tests/uconverter_getSourceEncoding.phpt
@@ -1,0 +1,14 @@
+--TEST--
+UConverter::getSourceEncoding()
+--CREDITS--
+Andy McNeice - PHP Testfest 2017
+--INI--
+intl.error_level = E_WARNING
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+$c = new UConverter('utf-32', 'ascii');
+var_dump($c->getSourceEncoding());
+--EXPECT--
+string(8) "US-ASCII"


### PR DESCRIPTION
Test covers previously uncovered lines at 
http://gcov.php.net/PHP_HEAD/lcov_html/ext/intl/converter/converter.c.gcov.php : 472-475

Ensures that the constructor is setting the appropriate source encoding.  