### PR TITLE
added basic test for UConverter::getDestinationEncoding()

### DIFF
--- a/ext/intl/tests/uconverter_getDestinationEncoding.phpt
+++ b/ext/intl/tests/uconverter_getDestinationEncoding.phpt
@@ -1,0 +1,14 @@
+--TEST--
+UConverter::getDestinationEncoding()
+--CREDITS--
+Andy McNeice - PHP Testfest 2017
+--INI--
+intl.error_level = E_WARNING
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+$c = new UConverter('UTF-7', 'ascii');
+var_dump($c->getDestinationEncoding());
+--EXPECT--
+string(5) "UTF-7"


### PR DESCRIPTION
Test covers previously uncovered lines at
http://gcov.php.net/PHP_HEAD/lcov_html/ext/intl/converter/converter.c.gcov.php : 479-482

Ensures that the constructor is setting the appropriate destination encoding.