### PR TITLE
added basic test for UConverter::setSourceEncoding()

### DIFF
--- a/ext/intl/tests/uconverter_setSourceEncoding.phpt
+++ b/ext/intl/tests/uconverter_setSourceEncoding.phpt
@@ -1,0 +1,17 @@
+--TEST--
+UConverter::setSourceEncoding()
+--CREDITS--
+Andy McNeice - PHP Testfest 2017
+--INI--
+intl.error_level = E_WARNING
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+$c = new UConverter('latin1', 'ascii');
+var_dump($c->getSourceEncoding());
+$c->setSourceEncoding('utf-7');
+var_dump($c->getSourceEncoding());
+--EXPECT--
+string(8) "US-ASCII"
+string(5) "UTF-7"


### PR DESCRIPTION
Test covers previously uncovered lines at
http://gcov.php.net/PHP_HEAD/lcov_html/ext/intl/converter/converter.c.gcov.php : 431-434

Verifies that the source encoding can be updated using the set method. 