### PR TITLE
PHP TestFest 2017 - Istanbul PHP UG - Test for readline_info() 

### DIFF
--- a/ext/readline/tests/readline_info_error.phpt
+++ b/ext/readline/tests/readline_info_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 readline_info(): Basic test
+--CREDITS--
+Burak Çakırel @burakcakirel - Istanbul PHP UG - PHP Testfest 2017
 --SKIPIF--
 <?php if (!extension_loaded("readline")) die("skip");
 if (READLINE_LIB == "libedit") die("skip readline only");

--- a/ext/readline/tests/readline_info_error.phpt
+++ b/ext/readline/tests/readline_info_error.phpt
@@ -1,0 +1,15 @@
+--TEST--
+readline_info(): Basic test
+--SKIPIF--
+<?php if (!extension_loaded("readline")) die("skip");
+if (READLINE_LIB == "libedit") die("skip readline only");
+?>
+--FILE--
+<?php
+
+var_dump(readline_info('line_buffer', 1, 'error'));
+
+?>
+--EXPECTF--
+Warning: readline_info() expects at most 2 parameters, 3 given in %s on line %d
+NULL


### PR DESCRIPTION
Add test for readline_info() too many arguments error