### PR TITLE
New Test for sunrise at North and South Pole

### DIFF
--- a/ext/date/tests/date_sunrise_variation10.phpt
+++ b/ext/date/tests/date_sunrise_variation10.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test date_sunrise() function : function returns false when the sun don't rise
+--FILE--
+<?php
+
+echo "*** The sun is all day up at 26 Jul 2017 at the North Pole ***\n";
+var_dump(date_sunrise(mktime(0, 0, 0, 7, 26, 2017), SUNFUNCS_RET_STRING, 84.430519, 4.218750));
+
+echo "*** The sun don't rise at 26 Jul 2017 at the South Pole ***\n";
+var_dump(date_sunrise(mktime(0, 0, 0, 7, 26, 2017), SUNFUNCS_RET_STRING, -80.605880, -1.757813));
+
+echo "===DONE===";
+--EXPECTF--
+*** The sun is all day up at 26 Jul 2017 at the North Pole ***
+bool(false)
+*** The sun don't rise at 26 Jul 2017 at the South Pole ***
+bool(false)
+===DONE===


### PR DESCRIPTION
This tests validates if the `date_sunrise` function returns `false` at the 26 July for both Poles.
On this day the sun did not rise at both locations. At the North Pole because the sun is up the hole day and at the South Pole because it's night for 24 hours.

This Test was contributed by the PHP Usergroup Münster (phpugms)