### PR TITLE
add test for ftp_set_option function to increase linecoverage

### DIFF
--- a/ext/ftp/tests/ftp_get_option_basic.phpt
+++ b/ext/ftp/tests/ftp_get_option_basic.phpt
@@ -12,10 +12,7 @@ $ftp = ftp_connect('127.0.0.1', $port);
 if (!$ftp) die("Couldn't connect to the server");
 ftp_login($ftp, 'user', 'pass');
 
-echo "*** Test by calling method or function with no arguments ***\n";
-var_dump(ftp_get_option( null, FTP_TIMEOUT_SEC ) );
-
-echo "\n*** Test by calling method or function with required arguments ***\n";
+echo "*** Test by calling method or function with required arguments ***\n";
 
 var_dump(ftp_get_option( $ftp, FTP_USEPASVADDRESS ) );
 
@@ -25,11 +22,6 @@ var_dump(ftp_get_option( $ftp, FTP_TIMEOUT_SEC ) );
 
 ?>
 --EXPECTF--
-*** Test by calling method or function with no arguments ***
-
-Warning: ftp_get_option() expects parameter 1 to be resource, null given in %s
-NULL
-
 *** Test by calling method or function with required arguments ***
 bool(true)
 bool(true)

--- a/ext/ftp/tests/ftp_get_option_basic.phpt
+++ b/ext/ftp/tests/ftp_get_option_basic.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test function ftp_get_option() by calling it with its expected arguments
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+ftp_login($ftp, 'user', 'pass');
+
+echo "*** Test by calling method or function with no arguments ***\n";
+var_dump(ftp_get_option( null, FTP_TIMEOUT_SEC ) );
+
+echo "\n*** Test by calling method or function with required arguments ***\n";
+
+var_dump(ftp_get_option( $ftp, FTP_USEPASVADDRESS ) );
+
+var_dump(ftp_get_option( $ftp, FTP_AUTOSEEK ) );
+
+var_dump(ftp_get_option( $ftp, FTP_TIMEOUT_SEC ) );
+
+?>
+--EXPECTF--
+*** Test by calling method or function with no arguments ***
+
+Warning: ftp_get_option() expects parameter 1 to be resource, null given in %s
+NULL
+
+*** Test by calling method or function with required arguments ***
+bool(true)
+bool(true)
+int(90)

--- a/ext/ftp/tests/ftp_set_option_basic.phpt
+++ b/ext/ftp/tests/ftp_set_option_basic.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test function ftp_set_option() by calling it with its expected arguments
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+ftp_login($ftp, 'user', 'pass');
+
+echo "*** Test by calling method or function with required arguments ***\n";
+
+var_dump(ftp_set_option( $ftp, FTP_USEPASVADDRESS, false ) );
+
+var_dump(ftp_set_option( $ftp, FTP_AUTOSEEK, false ) );
+
+var_dump(ftp_set_option( $ftp, FTP_TIMEOUT_SEC, 60 ) );
+
+echo "\n*** check if new parameters are set ***\n";
+
+var_dump(ftp_get_option( $ftp, FTP_USEPASVADDRESS ) );
+
+var_dump(ftp_get_option( $ftp, FTP_AUTOSEEK ) );
+
+var_dump(ftp_get_option( $ftp, FTP_TIMEOUT_SEC ) );
+
+?>
+--EXPECTF--
+*** Test by calling method or function with required arguments ***
+bool(true)
+bool(true)
+bool(true)
+
+*** check if new parameters are set ***
+bool(false)
+bool(false)
+int(60)


### PR DESCRIPTION
To fulfill the ftp_get_option test, this test will cover the untested function ftp_set_option. It should test the declared setters: http://gcov.php.net/PHP_7_1/lcov_html/ext/ftp/php_ftp.c.gcov.php#1447

This test was provided by the PHP Usergroup Münster (phpugms)