### PR TITLE
add test for error handling of ftp_set_option function

### DIFF
--- a/ext/ftp/tests/ftp_set_option_error.phpt
+++ b/ext/ftp/tests/ftp_set_option_error.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test function ftp_set_option() error handling by calling it with some bad arguments
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+ftp_login($ftp, 'user', 'pass');
+
+echo "*** Test by calling method or function width bad arguments ***\n";
+
+var_dump(ftp_set_option( $ftp, FTP_USEPASVADDRESS, 'phpugms' ) );
+
+var_dump(ftp_set_option( $ftp, FTP_AUTOSEEK, 'phpugms' ) );
+
+var_dump(ftp_set_option( $ftp, FTP_TIMEOUT_SEC, 'phpugms' ) );
+
+var_dump(ftp_set_option( $ftp, FTP_TIMEOUT_SEC, -12 ) );
+
+?>
+--EXPECTF--
+*** Test by calling method or function width bad arguments ***
+
+Warning: ftp_set_option(): Option USEPASVADDRESS expects value of type boolean, string given in %s
+bool(false)
+
+Warning: ftp_set_option(): Option AUTOSEEK expects value of type boolean, string given in %s
+bool(false)
+
+Warning: ftp_set_option(): Option TIMEOUT_SEC expects value of type long, string given in %s
+bool(false)
+
+Warning: ftp_set_option(): Timeout has to be greater than 0 in %s
+bool(false)
+


### PR DESCRIPTION
This test will cover the untested error handling of the function ftp_set_option. It should test all declared cases inside the function: http://gcov.php.net/PHP_7_1/lcov_html/ext/ftp/php_ftp.c.gcov.php#1447

This test was provided by the PHP Usergroup Münster (phpugms)