### PR TITLE
add test for error handling of ftp_get_option function

### DIFF
--- a/ext/ftp/tests/ftp_get_option_error.phpt
+++ b/ext/ftp/tests/ftp_get_option_error.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test function ftp_get_option() error handling by calling it with some bad arguments
+--SKIPIF--
+<?php
+require 'skipif.inc';
+?>
+--FILE--
+<?php
+require 'server.inc';
+
+define("FOO_BAR", 12);
+
+$ftp = ftp_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+ftp_login($ftp, 'user', 'pass');
+
+echo "*** Test by calling method or function width bad arguments ***\n";
+
+var_dump(ftp_get_option( $ftp, FOO_BAR ) );
+
+var_dump(ftp_get_option( null, FTP_TIMEOUT_SEC ) );
+?>
+--EXPECTF--
+*** Test by calling method or function width bad arguments ***
+
+Warning: ftp_get_option(): Unknown option '12' in %s
+bool(false)
+
+Warning: ftp_get_option() expects parameter 1 to be resource, null given in %s
+NULL

--- a/ext/ftp/tests/ftp_get_option_error.phpt
+++ b/ext/ftp/tests/ftp_get_option_error.phpt
@@ -17,14 +17,9 @@ ftp_login($ftp, 'user', 'pass');
 echo "*** Test by calling method or function width bad arguments ***\n";
 
 var_dump(ftp_get_option( $ftp, FOO_BAR ) );
-
-var_dump(ftp_get_option( null, FTP_TIMEOUT_SEC ) );
 ?>
 --EXPECTF--
 *** Test by calling method or function width bad arguments ***
 
 Warning: ftp_get_option(): Unknown option '12' in %s
 bool(false)
-
-Warning: ftp_get_option() expects parameter 1 to be resource, null given in %s
-NULL


### PR DESCRIPTION
This test will cover the untested error handling of the function ftp_get_option. It should test all declared cases inside the function: http://gcov.php.net/PHP_7_1/lcov_html/ext/ftp/php_ftp.c.gcov.php#1501

This test was provided by the PHP Usergroup Münster (phpugms)