### PR TITLE
PHP TestFest 2017 at PHPNW17 Conference - New tests for SPL DLL - Manually Iterate with Key

### DIFF
--- a/ext/spl/tests/SPLDoublyLinkedList_key_test.phpt
+++ b/ext/spl/tests/SPLDoublyLinkedList_key_test.phpt
@@ -1,0 +1,28 @@
+--TEST--
+SplDoublyLinkedList Tests for key() method when iterating "manually"
+--CREDITS--
+Mark Baker mark@lange.demon.co.uk at the PHPNW2017 Conference for PHP Testfest 2017
+--FILE--
+<?php
+
+// Setup our dll
+$dll = new SplDoublyLinkedList();
+
+for($i=2; $; <= 10; $i += 2) {
+    $dll->push(2);
+    $dll->push(3);
+}
+
+$dll->rewind();
+while ($dll->valid()) {
+    echo $dll->key(), ' => ', $dll->current();
+    $dll->next();
+}
+
+?>
+--EXPECT--
+0 => 2
+1 => 4
+2 => 6
+3 => 8
+4 => 10


### PR DESCRIPTION
Tests for key() method with DLLs when iterating manually