### PR TITLE
Added basic success test for xml_get_error_code

### DIFF
--- a/ext/xml/tests/xml_get_error_code_variation2.phpt
+++ b/ext/xml/tests/xml_get_error_code_variation2.phpt
@@ -13,12 +13,12 @@ if (!extension_loaded("xml")) {
 <?php
 
 $xmlParser = xml_parser_create();
-$xmlData = '<data><fruit>apple</fruit><bad>missing closing</data>';
+$xmlData = '<data><fruit>apple</fruit></data>';
 
 $isSuccess = xml_parse($xmlParser, $xmlData, true);
 
-var_dump(xml_get_error_code($xmlParser));
+var_dump(xml_get_error_code($xmlParser) == XML_ERROR_NONE);
 
 ?>
 --EXPECT--
-int(76)
+bool(true)

--- a/ext/xml/tests/xml_get_error_code_variation2.phpt
+++ b/ext/xml/tests/xml_get_error_code_variation2.phpt
@@ -1,0 +1,24 @@
+--TEST--
+xml_get_error_code - Test returns error code
+--CREDIT--
+Mark Niebergall <mbniebergall@gmail.com>
+PHP TestFest 2017 - UPHPU
+--SKIPIF--
+<?php 
+if (!extension_loaded("xml")) {
+    print "skip - XML extension not loaded";
+}
+?>
+--FILE--
+<?php
+
+$xmlParser = xml_parser_create();
+$xmlData = '<data><fruit>apple</fruit><bad>missing closing</data>';
+
+$isSuccess = xml_parse($xmlParser, $xmlData, true);
+
+var_dump(xml_get_error_code($xmlParser));
+
+?>
+--EXPECT--
+int(76)


### PR DESCRIPTION
Added basic success test for xml_get_error_code.

http://gcov.php.net/PHP_7_2/lcov_html/ext/xml/xml.c.gcov.php for line 1467

Credit: PHP TestFest 2017 - UPHPU