### PR TITLE
Added tests for xml_parser_set_option

### DIFF
--- a/ext/xml/tests/xml_parser_set_option_variation4.phpt
+++ b/ext/xml/tests/xml_parser_set_option_variation4.phpt
@@ -1,0 +1,29 @@
+--TEST--
+xml_parser_free - Test setting skip whitespace and invalid encoding type
+--CREDIT--
+Mark Niebergall <mbniebergall@gmail.com>
+PHP TestFest 2017 - UPHPU
+--SKIPIF--
+<?php
+if (!extension_loaded("xml")) {
+    print "skip - XML extension not loaded";
+}
+?>
+--FILE--
+<?php
+
+$xmlParser = xml_parser_create();
+
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_WHITE, 1));
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_WHITE, 0));
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_TARGET_ENCODING, 'UTF-8'));
+var_dump(xml_parser_set_option($xmlParser, XML_OPTION_TARGET_ENCODING, 'Invalid Encoding'));
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)
+
+Warning: xml_parser_set_option(): Unsupported target encoding "Invalid Encoding" in %s on line %d
+bool(false)

--- a/ext/xml/tests/xml_parser_set_option_variation4.phpt
+++ b/ext/xml/tests/xml_parser_set_option_variation4.phpt
@@ -15,14 +15,10 @@ if (!extension_loaded("xml")) {
 $xmlParser = xml_parser_create();
 
 var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_WHITE, 1));
-var_dump(xml_parser_set_option($xmlParser, XML_OPTION_SKIP_WHITE, 0));
-var_dump(xml_parser_set_option($xmlParser, XML_OPTION_TARGET_ENCODING, 'UTF-8'));
 var_dump(xml_parser_set_option($xmlParser, XML_OPTION_TARGET_ENCODING, 'Invalid Encoding'));
 
 ?>
 --EXPECTF--
-bool(true)
-bool(true)
 bool(true)
 
 Warning: xml_parser_set_option(): Unsupported target encoding "Invalid Encoding" in %s on line %d


### PR DESCRIPTION
Added tests when setting the skip whitespace option for xml_parser_set_option and tests when setting the target encoding with an invalid value, which triggers the "Unsupported target encoding..." error.

Tests http://gcov.php.net/PHP_7_2/lcov_html/ext/xml/xml.c.gcov.php lines 1604-1606 and 1612-1613.

Credit: PHP TestFest 2017 - Utah PHP User Group (UPHPU)