### PR TITLE
set variable register_argc_argv On on INI section

### DIFF
--- a/sapi/phpdbg/tests/run_001.phpt
+++ b/sapi/phpdbg/tests/run_001.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test argv passing
+--INI--
+register_argc_argv=On
 --PHPDBG--
 r
 r 1 2 3

--- a/sapi/phpdbg/tests/run_001.phpt
+++ b/sapi/phpdbg/tests/run_001.phpt
@@ -54,5 +54,7 @@ prompt>
 1 2 3
 --FILE--
 <?php
-
+if is_null($argc) || is_null($argv) {
+  die("Error. No parameters inserted!");
+}
 var_dump($argc, $argv);


### PR DESCRIPTION
Set the variable register_argc_argv On.
Without this parameter, the test suite can freeze without alert the user (This problem has occured with me when I was creating a VM to use on testfest event in Brazil).
 User Group: PHPSP #phptestfestbrasil
http://phpsp.org.br/