### PR TITLE
Test readline_info function : wrong parameter

### DIFF
--- a/ext/readline/tests/readline_info_wrongparam_001.phpt
+++ b/ext/readline/tests/readline_info_wrongparam_001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test readline_info function : wrong parameter (array)
+- line 248 from readline.c
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #phptestfestbrasil
+http://phpsp.org.br/
+--SKIPIF--
+<?php if (!extension_loaded("readline")) die("skip");
+if (READLINE_LIB == "libedit") die("skip readline only"); ?>
+--FILE--
+<?php
+$wrong_parameter = array();
+$info = readline_info($wrong_parameter);
+?>
+--EXPECTF--
+Warning: readline_info() expects parameter 1 to be string, array given in %s on line %d


### PR DESCRIPTION
Test readline_info function : wrong parameter (array)
- line 248 from readline.c
User Group: PHPSP #phptestfestbrasil
http://phpsp.org.br/