### PR TITLE
Create readline_wrongparam_002.phpt

### DIFF
--- a/ext/readline/tests/readline_wrongparam_002.phpt
+++ b/ext/readline/tests/readline_wrongparam_002.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Check the function readline with 2 parameters (wrong because the function expects only one parameter).
+- lines from 221 to 223 - readline.c
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #phptestfestbrasil
+http://phpsp.org.br/
+--SKIPIF--
+<?php if (!extension_loaded("readline") die("skip"); ?>
+--FILE--
+<?php
+$line = readline("Prompt", true);
+?>
+--EXPECTF--
+Warning: readline() expects at most 1 parameter, 2 given in %s on line %d


### PR DESCRIPTION
Check the function readline with 2 parameters (wrong because the function expects only one parameter).
- lines from 221 to 223 - readline.c
User Group: PHPSP #phptestfestbrasil