### PR TITLE
Small change in the test to pass

### DIFF
--- a/ext/zlib/tests/inflate_add_basic.phpt
+++ b/ext/zlib/tests/inflate_add_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test incremental inflate_add() functionality
+--INI--
+max_execution_time=10
 --SKIPIF--
 <?php
 if (!extension_loaded("zlib")) {


### PR DESCRIPTION
This test was not passing because the VM called by travis CI is slow, see below the failure:
http://gcov.php.net/viewer.php?version=PHP_HEAD&func=tests&file=ext%2Fzlib%2Ftests%2Finflate_add_basic.phpt
So I included the INI section with max_execution_time=10 and the test passed:
=====================================================================
Running selected tests.
PASS Test incremental inflate_add() functionality [/usr/src/phpt/inflate_add_basic.phpt] 
=====================================================================
Number of tests :    1                 1
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    1 (100.0%) (100.0%)

User Group: PHPSP #phptestfestbrasil
http://phpsp.org.br/