### PR TITLE
Add test for posix_getgrnam() basic functionality

### DIFF
--- a/ext/posix/tests/posix_getgrnam_basic.phpt
+++ b/ext/posix/tests/posix_getgrnam_basic.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test for function posix_getgrnam() basic functionality
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #PHPTestFestBrasil
+--SKIPIF--
+<?php 
+    if(!extension_loaded("posix")) die("skip - POSIX extension not loaded");
+?>
+--FILE--
+<?php
+$group_ids = posix_getgroups();
+
+if (is_null($group_ids) || (count($group_ids) == 0)) {
+    $group_ids[0] = false;
+}
+
+$group = posix_getgrgid($group_ids[0]);
+
+$group_name = $group['name'];
+
+$info_group = posix_getgrnam($group_name);
+
+var_dump($group_name == $info_group['name']);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
The test coverage the function posix_getgrnam() that was not covered yet.
http://gcov.php.net/PHP_HEAD/lcov_html/ext/posix/posix.c.gcov.php#1062
Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
User Group: PHPSP #PHPTestFestBrasil