### PR TITLE
Test for function extract() using a invalid prefix

### DIFF
--- a/ext/standard/tests/array/extract_error_2.phpt
+++ b/ext/standard/tests/array/extract_error_2.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test for function extract() using a invalid prefix
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #PHPTestFestBrasil
+--FILE--
+<?php
+$size = "large";
+
+$var_array = array("color" => "blue",
+                   "size"  => "medium",
+                   "shape" => "sphere");
+
+$valid_prefix = "wddx";
+extract($var_array, EXTR_PREFIX_SAME, $valid_prefix);
+echo "$color, $size, $shape, $wddx_size";
+
+$invalid_prefix = 1;
+extract($var_array, EXTR_PREFIX_SAME, $invalid_prefix);
+?>
+--EXPECTF--
+blue, large, sphere, medium
+Warning: extract(): prefix is not a valid identifier in %s on line %d


### PR DESCRIPTION
Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
User Group: PHPSP #PHPTestFestBrasil

Note that this test is not a ZPP test, but is covering the lines 2486-2487 from the file /ext/standard/array.c:
http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/array.c.gcov.php#L2486-2487