### PR TITLE
Test function strripos() - error

### DIFF
--- a/ext/standard/tests/strings/strripos_error_2.phpt
+++ b/ext/standard/tests/strings/strripos_error_2.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test function strripos() - Gets a warning when the offset is greater than the length of haystack string
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #PHPTestFestBrasil
+--FILE--
+<?php
+$haystack = 'ababcd';
+$needle   = 'aB';
+$offset = 7;
+
+var_dump(strripos($haystack, $needle, $offset));
+?>
+--EXPECTF--
+Warning: strripos(): Offset is greater than the length of haystack string in %s on line %d
+bool(false)


### PR DESCRIPTION
Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
User Group: PHPSP #PHPTestFestBrasil

Test to get a warning when the offset is greater than the length of haystack string
This test coverages the lines 2172-2174 from file /ext/standard/string.c:
http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/string.c.gcov.php