### PR TITLE
Test function quotemeta() - using an empty string is given as str

### DIFF
--- a/ext/standard/tests/strings/quotemeta_basic_1.phpt
+++ b/ext/standard/tests/strings/quotemeta_basic_1.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test function quotemeta() - using an empty string is given as str.
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #PHPTestFestBrasil
+--FILE--
+<?php
+$str = "";
+var_dump(quotemeta($str));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
User Group: PHPSP #PHPTestFestBrasil

Test function quotemeta() - using an empty string is given as str.
This test coverage line 2596 from file /ext/standard/string.c and is not a ZPP test.
http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/string.c.gcov.php#L2596