### PR TITLE
Test addcslashes() function : basic functionality using "\a" and "\b"

### DIFF
--- a/ext/standard/tests/strings/addcslashes_006.phpt
+++ b/ext/standard/tests/strings/addcslashes_006.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test addcslashes() function : basic functionality using "\a" and "\b"
+--CREDITS--
+Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
+User Group: PHPSP #PHPTestFestBrasil
+--FILE--
+<?php
+$string = "string to be escaped is \a";
+var_dump(addcslashes($string, '\a'));
+
+$string = "string to be escaped is \b";
+var_dump(addcslashes($string, '\b'));
+?>
+--EXPECTF--
+string(29) "string to be esc\aped is \\\a"
+string(29) "string to \be escaped is \\\b"


### PR DESCRIPTION
Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
User Group: PHPSP #PHPTestFestBrasil

Test addcslashes() function : basic functionality using "\a" and "\b"
This test coverage the lines 3835 and 3837 from file /ext/standard/string.c
http://gcov.php.net/PHP_HEAD/lcov_html/ext/standard/string.c.gcov.php
