### PR TITLE
Added basic stream_filter_register test

### DIFF
--- a/ext/standard/tests/streams/stream_filter_register.phpt
+++ b/ext/standard/tests/streams/stream_filter_register.phpt
@@ -1,0 +1,25 @@
+--TEST--
+testing the behavior of stream_filter_register
+--CREDITS--
+Robrecht Plaisier <php@mcq8.be>
+User Group: PHP-WVL & PHPGent #PHPTestFest
+--FILE--
+<?php
+class foo extends php_user_filter {
+  function filter($in, $out, &$consumed, $closing) {
+  }
+}
+
+class bar extends php_user_filter {
+  function filter($in, $out, &$consumed, $closing) {
+  }
+}
+
+var_dump(stream_filter_register("myfilter","foo"));
+var_dump(stream_filter_register("myfilter","bar"));
+var_dump(stream_filter_register("foo","foo"));
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
User Group: PHP-WVL & PHPGent

stream_filter_register() will return FALSE if the filtername is already defined, was not tested yet.