### PR TITLE
gd imageloadfont test while reading header

### DIFF
--- a/ext/gd/tests/imageloadfont_end_of_file_while_reading_header.phpt
+++ b/ext/gd/tests/imageloadfont_end_of_file_while_reading_header.phpt
@@ -1,0 +1,23 @@
+--TEST--
+imageloadfont() "End of file while reading header"
+--CREDITS--
+Ike Devolder <ike.devolder@gmail.com>
+User Group: PHP-WVL & PHPGent #PHPTestFest
+--SKIPIF--
+<?php
+	if (!extension_loaded('gd')) die("skip gd extension not available\n");
+?>
+--FILE--
+<?php
+$filename = dirname(__FILE__) .  '/font.gdf';
+$bin = "\x41\x41\x41\x41\x00\x00\x00\x00\x00\x00";
+$fp = fopen($filename, 'wb');
+fwrite($fp, $bin);
+fclose($fp);
+
+$font = imageloadfont($filename);
+
+unlink($filename);
+?>
+--EXPECTF--
+Warning: imageloadfont(): End of file while reading header in %s on line %d


### PR DESCRIPTION
Cover error when the header of an gd font loading is interrupted by end
of file.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

User Group: PHP-WVL & PHPGent #PHPTestFest