### PR TITLE
gd imageloadfont, verify error while reading header

### DIFF
--- a/ext/gd/tests/imageloadfont_error_while_reading_header.phpt
+++ b/ext/gd/tests/imageloadfont_error_while_reading_header.phpt
@@ -1,0 +1,23 @@
+--TEST--
+imageloadfont() "Error while reading header"
+--CREDITS--
+Ike Devolder <ike.devolder@gmail.com>
+User Group: PHP-WVL & PHPGent #PHPTestFest
+--SKIPIF--
+<?php
+	if (!extension_loaded('gd')) die("skip gd extension not available\n");
+?>
+--FILE--
+<?php
+$filename = dirname(__FILE__) .  '/font.gdf';
+$bin = "\xe0\x00\x00\x00\x20\x00\x00\x00\x06\x00\x00\x00\x0a\x00\x00";
+$fp = fopen($filename, 'wb');
+fwrite($fp, $bin);
+fclose($fp);
+
+$font = imageloadfont($filename);
+
+unlink($filename);
+?>
+--EXPECTF--
+Warning: imageloadfont(): End of file while reading header in %s on line %d


### PR DESCRIPTION
when reading the header verify we get an error when the header is
invalid.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

User Group: PHP-WVL & PHPGent #PHPTestFest