### PR TITLE
Test the 'Unknown encoding' warning of the mb_strcut function

### DIFF
--- a/ext/mbstring/tests/mb_strcut1.phpt
+++ b/ext/mbstring/tests/mb_strcut1.phpt
@@ -1,6 +1,6 @@
 --TEST--
 mb_strcut() - unknown encoding
--- CREDITS --
+--CREDITS--
 Jachim Coudenys <jachimcoudenys@gmail.com>
 User Group: PHP-WVL & PHPGent #PHPTestFest
 --SKIPIF--

--- a/ext/mbstring/tests/mb_strcut1.phpt
+++ b/ext/mbstring/tests/mb_strcut1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+mb_strcut() - unknown encoding
+-- CREDITS --
+Jachim Coudenys <jachimcoudenys@gmail.com>
+User Group: PHP-WVL & PHPGent #PHPTestFest
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--INI--
+output_handler=
+--FILE--
+<?php
+mb_strcut('coudenys', 0, 4, 'jachim');
+?>
+--EXPECTF--
+Warning: mb_strcut(): Unknown encoding "jachim" in %s on line %d


### PR DESCRIPTION
User Group: PHP-WVL & PHPGent #PHPTestFest

This covers http://gcov.php.net/PHP_7_2/lcov_html/ext/mbstring/mbstring.c.gcov.php line 3005.