### PR TITLE
Test the 'Unknown encoding' warning of the mb_strwith function

### DIFF
--- a/ext/mbstring/tests/mb_strwidth1.phpt
+++ b/ext/mbstring/tests/mb_strwidth1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+mb_strwidth() - unknown encoding
+--CREDITS--
+Jachim Coudenys <jachimcoudenys@gmail.com>
+User Group: PHP-WVL & PHPGent #PHPTestFest
+--SKIPIF--
+<?php extension_loaded('mbstring') or die('skip mbstring not available'); ?>
+--INI--
+output_handler=
+--FILE--
+<?php
+mb_strwidth('coudenys', 'jachim');
+?>
+--EXPECTF--
+Warning: mb_strwidth(): Unknown encoding "jachim" in %s on line %d


### PR DESCRIPTION
User Group: PHP-WVL & PHPGent #PHPTestFest

This covers http://gcov.php.net/PHP_7_2/lcov_html/ext/mbstring/mbstring.c.gcov.php line 3077.